### PR TITLE
Allow dynamic passing of Catalog URL in WMTS requests

### DIFF
--- a/titiler/stacapi/utils.py
+++ b/titiler/stacapi/utils.py
@@ -4,6 +4,7 @@ Code from titiler.pgstac and titiler.cmr, MIT License.
 
 """
 
+import base64
 import re
 import time
 from typing import Any, List, Optional
@@ -11,6 +12,13 @@ from typing import Any, List, Optional
 from morecantile import TileMatrixSet
 from starlette.requests import Request
 from starlette.templating import Jinja2Templates, _TemplateResponse
+
+def encode_catalog_url(catalog_url: str) -> str:
+    return base64.urlsafe_b64encode(catalog_url.encode('utf-8')).decode('utf-8')
+
+
+def decode_catalog_url(encoded_catalog_url: str) -> str:
+    return base64.urlsafe_b64decode(encoded_catalog_url.encode('utf-8')).decode('utf-8').strip()
 
 
 def create_html_response(


### PR DESCRIPTION
TiTiler STAC has been extended to allow passing of STAC catalog URLs dynamically.
This is important for us with the DataHub as we rely on sub catalogs.

---

My original plan was to pass the `catalog_url` as part of the request parameters. However, as `catalog_url` is not part of the OGC WMTS standard, it would simply get removed on the following request. 

This had to be rethought as passing the catalog url as a prefix to `/wmts` in each request. However, as STAC catalogs can be a domain and a path, this extra path would subsequently confuse TiTiler as it would return a 404. 

Ultimately, the solution that worked was Base64 encoding the catalog URL and using that as a path prefix. 

**For example:**
if we want to serve the `sentinel2_ard` collection from CEDA stored here:
https://dev.eodatahub.org.uk/api/catalogue/stac/catalogs/supported-datasets/ceda-stac-catalogue/collections/sentinel2_ard

Base64 encoding this URL would get: aHR0cHM6Ly9kZXYuZW9kYXRhaHViLm9yZy51ay9hcGkvY2F0YWxvZ3VlL3N0YWMvY2F0YWxvZ3Mvc3VwcG9ydGVkLWRhdGFzZXRzL2NlZGEtc3RhYy1jYXRhbG9ndWUvCg==

Now passing that in the url such as `https://my-stac-titiler.com/titiler/stac/<base64-encoded-catalog-url>/wmts?request=GetCapabilities` would now work.

An example complete URL:
`https://dev.eodatahub.org.uk/titiler/stac/aHR0cHM6Ly9kZXYuZW9kYXRhaHViLm9yZy51ay9hcGkvY2F0YWxvZ3VlL3N0YWMvY2F0YWxvZ3Mvc3VwcG9ydGVkLWRhdGFzZXRzL2NlZGEtc3RhYy1jYXRhbG9ndWUvCg==/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=sentinel2_ard_rgb&STYLE=default&FORMAT=image/png&TILEMATRIXSET=WebMercatorQuad&TILEMATRIX=12&TIME=2023-09-03&TILEROW=1335&TILECOL=2025`

That can be broken down to:
```
SERVICE: WMTS
REQUEST: GetTile
VERSION: 1.0.0
LAYER: sentinel2_ard_rgb
STYLE: default
FORMAT: image/png
TILEMATRIXSET: WebMercatorQuad
TILEMATRIX: 12
TIME: 2023-09-03
TILEROW: 1335
TILECOL: 2025
```

And ultimately would give us:
![wmts](https://github.com/user-attachments/assets/3c226b90-448c-49b4-b4dc-622f993cf087)

